### PR TITLE
Make pkr_extractor work on POSIX

### DIFF
--- a/pkr_extractor/Makefile
+++ b/pkr_extractor/Makefile
@@ -5,10 +5,10 @@ CFLAGS = -std=c11 -g -static
 all: pkr 
 
 %.o: %.c
-		$(CC) -c -o $@ $< $(CFLAGS) $(LIBS)
+		$(CC) -c -o $@ $< $(CFLAGS)
 
 pkr: $(OBJ)
-		gcc -o $@ $^ $(CFLAGS) $(LIBS)
+		$(CC) -o $@ $^ $(CFLAGS) $(LIBS)
 
 clean:
 		rm -rf *.o

--- a/pkr_extractor/extract.c
+++ b/pkr_extractor/extract.c
@@ -1,6 +1,5 @@
 #include "pkr.h"
-#include <sys/stat.h>
-#include <sys/types.h>
+#include "mkdir.h"
 #include <errno.h>
 
 #include <zlib.h>

--- a/pkr_extractor/extract.c
+++ b/pkr_extractor/extract.c
@@ -37,10 +37,20 @@ uint32_t GetPkrFile(PKRFile *file){
 bool ExtractDir(PKRDir *curDir){
 
 	//Set the path
-	strcpy(buffer, "extracted\\\0");
-	strncat(buffer, (char*)curDir, 0x20);
+	strcpy(buffer, "extracted/");
+	buffer[strlen(buffer) + 0x20] = '\0';
+	strncat(buffer, curDir->name, 0x20);
 
-	uint32_t pathLen = strlen("extracted\\") + strlen((char*)curDir);
+	//Replace backslash by forwardslash for POSIX
+	char* cursor = buffer;
+	while(*cursor != '\0'){
+		if(*cursor == '\\'){
+			*cursor = '/';
+		}
+		cursor++;
+	}
+
+	uint32_t pathLen = strlen("extracted/") + strlen((char*)curDir);
 	buffer[pathLen] = '\0';
 
 	printf("Extracting %s\n", &curDir->name);

--- a/pkr_extractor/mkdir.h
+++ b/pkr_extractor/mkdir.h
@@ -1,0 +1,4 @@
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#define mkdir(path) mkdir((path), 0777)

--- a/pkr_extractor/walk.c
+++ b/pkr_extractor/walk.c
@@ -1,7 +1,6 @@
 //Related to walking the PKR3 Files directories
 #include "pkr.h"
-#include <sys/stat.h>
-#include <sys/types.h>
+#include "mkdir.h"
 #include <errno.h>
 
 #include <zlib.h>


### PR DESCRIPTION
I required these changes for my platform (Linux).

I'm not sure where the original `mkdir` with only 1 argument originated from.
It's possible that the mkdir.h is therefore incorrect (needs some pre-processor check).
For now, I assumed that the original function was `mkdir(const char* path, ...)`.