### PR TITLE
Disable fatal error on CRC check in pkr_extractor

### DIFF
--- a/pkr_extractor/extract.c
+++ b/pkr_extractor/extract.c
@@ -192,6 +192,7 @@ bool WriteFileToDisk(PKRFile *file){
 	//CRC Check
 	if(!CalculateExtractedCrc(file)){
 		printf("Invalid CRC for %s\n", file->name);
+#if 0
 		fclose(out);
 		if(auxExtractBuf){
 			free(auxExtractBuf);
@@ -199,6 +200,7 @@ bool WriteFileToDisk(PKRFile *file){
 		}
 		return false;
 
+#endif
 	}
 
 	if(!(fwrite(curExtBuf, file->uncompressedSize, 1, out))){


### PR DESCRIPTION
There are some CRC errors in the data.pkr that I have. I'm not sure if my disc is broken, or if this is a bug in this tool.
I decided to disable the failure handling for CRC check for now.