### PR TITLE
Fix type of uncompress() destLen argument in pkr_extractor

### DIFF
--- a/pkr_extractor/extract.c
+++ b/pkr_extractor/extract.c
@@ -256,8 +256,8 @@ uint8_t *DecompressFile(PKRFile *file){
 		return false;
 	}
 
-	uint32_t finalSize = file->uncompressedSize;
-	if(uncompress(outBuffer, (uLongf*)&finalSize, curExtBuf, file->compressedSize) != Z_OK){
+	uLongf finalSize = (uLongf)file->uncompressedSize;
+	if(uncompress(outBuffer, &finalSize, curExtBuf, file->compressedSize) != Z_OK){
 		puts("Error uncompressing the file :(");
 		return false;
 	}


### PR DESCRIPTION
This fixes a crash and corruption with data.pkr from a European Windows release. I'd get `errno` 14 (`EFAULT` / Bad address) from `fwrite` in  `WriteFileToDisk`; particularly a null-pointer as source address.

I traced it back to this:

```
Starting program: spidey-tools/pkr_extractor/pkr Spider-Man-Disc/Setup/data.pkr
Breakpoint 2, DecompressFile (file=0x7fffffffe030) at extract.c:267
267	uint8_t *DecompressFile(PKRFile *file){
(gdb) n
268		uint8_t *outBuffer = NULL;
(gdb) 
269		outBuffer = malloc(file->uncompressedSize);
(gdb) 
271		if(!outBuffer){
(gdb) print outBuffer
$1 = (uint8_t *) 0x4d1b80 ""
(gdb) n
276		uint32_t finalSize = file->uncompressedSize;
(gdb) 
277		if(uncompress(outBuffer, (uLongf*)&finalSize, curExtBuf, file->compressedSize) != Z_OK){
(gdb) 
281		return outBuffer;
(gdb) print outBuffer
$2 = (uint8_t *) 0x0
```

So this turned out to be an issue where the size of `uLongf` and `uint32_t` mismatch. I changed the type and added an explicit cast to avoid potential size-change warnings.

*This does not seem to affect my US data.pkr in #6. However, my European data.pkr does not seem to cause any CRC mismatches.*