### PR TITLE
Updated psx_extractor to handle several alternative bitmap methods

### DIFF
--- a/psx_extractor/bmp.c
+++ b/psx_extractor/bmp.c
@@ -34,7 +34,7 @@ typedef struct __attribute__((packed)){
 	BmpImageHeader image; 
 }Bmp;
 
-bool WriteBmpFile(uint8_t *buffer, uint32_t width, uint32_t height, uint32_t fileName){
+bool WriteBmpFile(uint8_t *buffer, uint32_t width, uint32_t height, uint32_t fileName, uint32_t palette){
 	
 	static Bmp extracted;
 	memset(&extracted, 0, sizeof(Bmp));
@@ -55,11 +55,49 @@ bool WriteBmpFile(uint8_t *buffer, uint32_t width, uint32_t height, uint32_t fil
 	extracted.image.xpm = extracted.image.ypm = 
 		extracted.image.clrUsed = extracted.image.clrImp = 0;
 
-	
-	extracted.image.redMask = 0xF800;
-	extracted.image.blueMask = 0x1F;
-	extracted.image.greenMask = 0x07E0;
+	uint32_t red_mask = 0xF800;
+	uint32_t green_mask = 0x7E0;
+	uint32_t blue_mask = 0x1F;
 
+	switch (palette)
+	{
+		// 4444
+		case 770:
+		case 2306:
+			extracted.image.redMask = 0x0F00;
+			extracted.image.greenMask = 0xF0;
+			extracted.image.blueMask = 0xF;
+			extracted.image.alphaMask = 0xF000;
+			break;
+				
+		// 5551
+		// Alpha is either 0 or 128 for some reason
+		case 768:
+			extracted.image.redMask = 0x7C00;
+			extracted.image.greenMask = 0x3E0;
+			extracted.image.blueMask = 0x1F;
+			extracted.image.alphaMask = 0x8000;
+			break;
+			
+		// 565
+		// Pixels are not scrambled!
+		case 2305:
+			extracted.image.redMask = 0xF800;
+			extracted.image.greenMask = 0x7E0;
+			extracted.image.blueMask = 0x1F;
+			extracted.image.alphaMask = 0;
+			break;
+		
+		// OTHER
+		default:
+		case 769:
+			extracted.image.redMask = 0xF800;
+			extracted.image.greenMask = 0x07E0;
+			extracted.image.blueMask = 0x1F;
+			extracted.image.alphaMask = 0;
+			break;
+	}
+	
 	char extractedName[32];
 	sprintf(extractedName, (nameAsAdd ? "%08X.bmp" : "%d.bmp"), fileName);
 


### PR DESCRIPTION
Necessary changes to parse textures that have alpha, are arranged differently, etc.